### PR TITLE
Update Status Filter to Radio

### DIFF
--- a/src/features/events/filters/StatusFilter.tsx
+++ b/src/features/events/filters/StatusFilter.tsx
@@ -1,9 +1,9 @@
 import {
     FormControl,
     FormControlLabel,
-    FormGroup,
     FormLabel,
-    Switch,
+    Radio,
+    RadioGroup,
 } from '@mui/material'
 
 import { useEvents } from '@/hooks'
@@ -11,40 +11,38 @@ import { useEvents } from '@/hooks'
 export const StatusFilter = () => {
     const {
         filter: {
-            filters: { closed, open },
+            filters: { status },
             handleFilterChange,
         },
     } = useEvents()
 
     return (
         <FormControl component="fieldset">
-            <FormLabel component="legend">Status</FormLabel>
-            <FormGroup sx={{ pl: 1 }}>
+            <FormLabel component="legend" id="status-filter-label">
+                Status
+            </FormLabel>
+            <RadioGroup
+                aria-labelledby="status-filter-label"
+                name="status"
+                onChange={(e) => handleFilterChange('status', e.target.value)}
+                sx={{
+                    '& .MuiFormControlLabel-root': {
+                        lineHeight: 1,
+                    },
+                }}
+                value={status}
+            >
                 <FormControlLabel
-                    control={
-                        <Switch
-                            aria-label={`${open ? 'Hide' : 'Show'} open events`}
-                            checked={open}
-                            onChange={() => handleFilterChange('open', !open)}
-                            size="small"
-                        />
-                    }
+                    control={<Radio size="small" />}
                     label="Open"
-                    name="open"
+                    value="open"
                 />
                 <FormControlLabel
-                    control={
-                        <Switch
-                            aria-label={`${closed ? 'Hide' : 'Show'} closed events`}
-                            checked={closed}
-                            onChange={() => handleFilterChange('closed', !closed)}
-                            size="small"
-                        />
-                    }
+                    control={<Radio size="small" />}
                     label="Closed"
-                    name="closed"
+                    value="closed"
                 />
-            </FormGroup>
+            </RadioGroup>
         </FormControl>
     )
 }

--- a/src/hooks/useFilters.ts
+++ b/src/hooks/useFilters.ts
@@ -7,10 +7,9 @@ import type { CategoryResponse, Filters, SourceResponse } from '@/types'
 
 const defaultFilters: Filters = {
     category: 'all',
-    closed: false,
     days: 30,
-    open: true,
     sources: [],
+    status: 'open',
 }
 
 export const useFilters = () => {
@@ -39,7 +38,7 @@ export const useFilters = () => {
     })
 
     const generateUrl = useCallback(() => {
-        const { category, closed, days, open, sources } = filters
+        const { category, days, sources, status } = filters
         let url = 'https://eonet.gsfc.nasa.gov/api/v2.1/'
 
         if (category !== 'all') {
@@ -55,10 +54,8 @@ export const useFilters = () => {
             queryParams.append('source', sources.join(','))
         }
 
-        if (open && !closed) {
-            // https://eonet.gsfc.nasa.gov/api/v2.1/events?status=open
-            queryParams.append('status', 'open')
-        } else if (!open && closed) {
+        // If no status is provided, the API will return only open events
+        if (status === 'closed') {
             // https://eonet.gsfc.nasa.gov/api/v2.1/events?status=closed
             queryParams.append('status', 'closed')
         }

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -43,10 +43,9 @@ export interface EventSource {
 
 export interface Filters {
     category: string
-    closed: boolean
     days: number
-    open: boolean
     sources: string[]
+    status: 'closed' | 'open'
 }
 
 export interface Response {


### PR DESCRIPTION
The API will automatically return only `open` status items if nothing is specified. Therefore it is impossible to show both `open` and `closed` items. This updates the status `switch` to be `radio` and only passes the query param when `closed` is selected.